### PR TITLE
V0 merge .1

### DIFF
--- a/src/frontend/src/components/TopicStreamForm.jsx
+++ b/src/frontend/src/components/TopicStreamForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-const TopicStreamForm = ({ onSubmit, initialData = null, isEditing = false }) => {
+const TopicStreamForm = ({ onSubmit, initialData = null, isEditing = false, onCancel }) => {
   const [formData, setFormData] = useState({
     query: '',
     update_frequency: 'daily',
@@ -170,13 +170,13 @@ const TopicStreamForm = ({ onSubmit, initialData = null, isEditing = false }) =>
           Topic Query <span className="text-red-500">*</span>
         </label>
         <div className="mt-1">
-          <input
-            type="text"
+          <textarea
             name="query"
             id="query"
             value={formData.query}
             onChange={handleChange}
-            className={`shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md ${
+            rows={3}
+            className={`shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md resize-y ${
               errors.query ? 'border-red-500' : ''
             }`}
             placeholder="Enter a topic query, e.g., 'latest AI developments'"
@@ -330,17 +330,25 @@ const TopicStreamForm = ({ onSubmit, initialData = null, isEditing = false }) =>
         </div>
       </div>
       
-      <div className="pt-4">
+      <div className="space-y-3">
         <button
           type="submit"
           disabled={isSubmitting}
-          className={`w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${
-            isSubmitting ? 'opacity-75 cursor-not-allowed' : ''
-          }`}
-          data-testid="create-stream-button"
+          className={`w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${isSubmitting ? 'opacity-75 cursor-not-allowed' : ''}`}
+          data-testid="update-stream-button"
         >
-          {isSubmitting ? (isEditing ? 'Updating...' : 'Creating...') : (isEditing ? 'Update Topic Stream' : 'Create Topic Stream')}
+          {isSubmitting ? 'Updating...' : 'Update Topic Stream'}
         </button>
+
+        {isEditing && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+        )}
       </div>
     </form>
   );

--- a/src/frontend/src/components/TopicStreamWidget.jsx
+++ b/src/frontend/src/components/TopicStreamWidget.jsx
@@ -249,307 +249,324 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
 
   return (
     <div className={`${isGridView ? 'lg:col-span-1' : 'w-full'} bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-200`}>
-      <div className={`p-4 border-b dark:border-gray-700 flex ${isGridView ? 'flex-col space-y-4' : 'justify-between items-start'}`}>
-        <div className={`${isGridView ? 'w-full' : 'flex-1 min-w-0 mr-4'}`}>
-          <h3 className={`text-lg font-semibold text-gray-900 dark:text-white ${isGridView ? 'line-clamp-3' : 'truncate'}`}>
-            {stream.query}
-          </h3>
-          <div className="flex flex-wrap gap-2 mt-2">
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-              {stream.update_frequency}
-            </span>
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-              {stream.detail_level}
-            </span>
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-              {stream.model_type}
-            </span>
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
-              {timeSinceLastUpdate}
-            </span>
-          </div>
+      {showEditForm ? (
+        <div className="p-4">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Edit Topic Stream</h3>
+          <TopicStreamForm
+            initialData={stream}
+            onSubmit={handleEditSubmit}
+            onCancel={() => setShowEditForm(false)}
+            isEditing={true}
+          />
         </div>
-        
-        {/* Buttons - right side, need conditional layout */}
-        {isGridView ? (
-          // Grid View Layout: Revert to original layout (left-aligned, all on one line)
-          <div className="flex flex-wrap gap-2 w-full justify-start relative"> {/* Revert to justify-start */}
-            <button
-              onClick={handleEdit}
-              className="text-xs py-1 px-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
-            >
-              Edit
-            </button>
-            <button
-              onClick={handleUpdateNow}
-              disabled={updating}
-              className={`text-xs py-1 px-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors ${
-                updating ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-            >
-              {updating ? 'Updating...' : 'Update Now'}
-            </button>
-
-            {/* Delete Button for Grid View */}
-            <button
-              onClick={handleDeleteStream}
-              className="text-xs py-1 px-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
-            >
-              Delete Stream
-            </button>
-
-            {/* Export Button for Grid View */}
-            <button
-              onClick={() => setShowExportOptions(!showExportOptions)}
-              className="text-xs py-1 px-2 rounded bg-gray-600 text-white hover:bg-gray-700 transition-colors"
-            >
-              Export
-            </button>
-
-            {/* Export Options Dropdown - positioned relative to this container */}
-            {showExportOptions && (
-              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
-                <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
-                  <button
-                    onClick={() => { copyToClipboard(); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Copy to Clipboard
-                  </button>
-                  <button
-                    onClick={() => { exportAsFile('md'); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Export as .md
-                  </button>
-                  <button
-                    onClick={() => { exportAsFile('txt'); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Export as .txt
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        ) : (
-          // List View Layout: Edit/Update on first line, Delete/Export on second, both right-aligned
-          <div className="flex flex-col items-end space-y-1 relative"> {/* items-end aligns flex items to the right */}
-            {/* First line: Edit, Update Now */}
-            <div className="flex space-x-1"> {/* Container for first line buttons */}
-              <button
-                onClick={handleEdit}
-                className="text-xs py-1 px-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
-              >
-                Edit
-              </button>
-              <button
-                onClick={handleUpdateNow}
-                disabled={updating}
-                className={`text-xs py-1 px-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors ${
-                  updating ? 'opacity-50 cursor-not-allowed' : ''
-                }`}
-              >
-                {updating ? 'Updating...' : 'Update Now'}
-              </button>
-            </div>
-
-            {/* Second line: Delete, Export */}
-            <div className="flex space-x-1 justify-end w-full"> {/* Ensure buttons are right-aligned on this line */}
-              <button
-                onClick={handleDeleteStream}
-                className="text-xs py-1 px-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
-              >
-                Delete Stream
-              </button>
-              <button
-                onClick={() => setShowExportOptions(!showExportOptions)}
-                className="text-xs py-1 px-2 rounded bg-gray-600 text-white hover:bg-gray-700 transition-colors"
-              >
-                Export
-              </button>
-            </div>
-
-            {/* Export Options Dropdown - positioned relative to the main flex-col container */}
-            {showExportOptions && (
-              <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
-                <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
-                  <button
-                    onClick={() => { copyToClipboard(); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Copy to Clipboard
-                  </button>
-                  <button
-                    onClick={() => { exportAsFile('md'); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Export as .md
-                  </button>
-                  <button
-                    onClick={() => { exportAsFile('txt'); setShowExportOptions(false); }}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                    role="menuitem"
-                  >
-                    Export as .txt
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      {error && !showDeleteStreamConfirm && (
-        <div className="p-4 bg-red-100 border-l-4 border-red-500 text-red-700">
-          <p>{error}</p>
-          <button onClick={() => setError('')} className="text-sm underline mt-1">Dismiss</button>
-        </div>
-      )}
-
-      <div className="divide-y dark:divide-gray-700">
-        {loading ? (
-          <div className="p-4 text-center text-gray-500 dark:text-gray-400">Loading summaries...</div>
-        ) : summaries.length === 0 && !error ? (
-          <div className="p-4 text-center text-gray-500 dark:text-gray-400">
-            No summaries yet. Click "Update Now" to generate one.
-          </div>
-        ) : (
-          summaries.map((summary) => (
-            <div key={summary.id} className="p-4">
-              <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Summary</h4>
-               <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                 <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
-                    {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
-                  </span>
-                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">{summary.model_type}</span>
-               </div>
-               <div className={`prose prose-sm max-w-none dark:prose-invert`}>
-                 <MarkdownRenderer content={summary.content} />
-               </div>
-               
-               {/* Summary Actions */}
-               <div className="flex space-x-2 mt-4">
-                  <button
-                   onClick={() => handleDeepDive(summary)}
-                   className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full"
-                 >
-                   Deep Dive
-                 </button>
-                  <SummaryDeleteButton 
-                   streamId={stream.id} 
-                   summaryId={summary.id}
-                   onSummaryDeleted={handleSummarySuccessfullyDeleted}
-                   onError={handleSummaryDeletionError} 
-                 />
-               </div>
-              
-               {/* Summary Sources */}
-               {summary.sources && summary.sources.length > 0 && (
-                 <div className="mt-3">
-                   <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
-                   <div className="flex flex-wrap gap-1">
-                     {summary.sources.map((source, index) => (
-                       <a
-                         key={index}
-                         href={typeof source === 'string' ? source : (source.url || source.name || source)}
-                         target="_blank"
-                         rel="noopener noreferrer"
-                         className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
-                         title={typeof source === 'string' ? source : (source.url || source.name || source)}
-                       >
-                         {typeof source === 'string' 
-                           ? source 
-                           : (source.name || source.url || source)}
-                       </a>
-                     ))}
-                   </div>
-                 </div>
-               )}
-            </div>
-          ))
-        )}
-      </div>
-
-      {showDeepDive && selectedSummary && (
-        <div className="fixed inset-0 z-50 bg-gray-500 bg-opacity-75 flex items-center justify-center p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-3/4 max-h-[90vh] overflow-hidden flex flex-col">
-            <div className="p-4 border-b dark:border-gray-700 flex justify-between items-center">
-              <h3 className="text-lg font-medium text-gray-900 dark:text-blue-300 truncate flex-1 min-w-0">
-                Deep Dive: {stream.query}
+      ) : (
+        <>
+          <div className={`p-4 border-b dark:border-gray-700 flex ${isGridView ? 'flex-col space-y-4' : 'justify-between items-start'}`}>
+            <div className={`${isGridView ? 'w-full' : 'flex-1 min-w-0 mr-4'}`}>
+              <h3 className={`text-lg font-semibold text-gray-900 dark:text-white ${isGridView ? 'line-clamp-3' : 'truncate'}`}>
+                {stream.query}
               </h3>
-              <button
-                onClick={() => setShowDeepDive(false)}
-                className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
-              >
-                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
+              <div className="flex flex-wrap gap-2 mt-2">
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                  {stream.update_frequency}
+                </span>
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                  {stream.detail_level}
+                </span>
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+                  {stream.model_type}
+                </span>
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
+                  {timeSinceLastUpdate}
+                </span>
+              </div>
             </div>
             
-            {/* Main content area with two columns */}
-            <div className="flex flex-1 overflow-hidden flex-row">
-              {/* Original Summary Section - Left Column */}
-              <div className="flex-1 basis-1/2 p-4 border-r dark:border-gray-700 overflow-y-auto">
-                <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Summary</h4>
-                <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                  {selectedSummary.created_at ? formatInTimeZone(toZonedTime(parseISO(selectedSummary.created_at), userTimeZone), userTimeZone, 'MMM d, yyyy h:mm a') : ''} • Model: {selectedSummary.model_type}
+            {/* Buttons - right side, need conditional layout */}
+            {isGridView ? (
+              // Grid View Layout: All buttons on one line, right-aligned
+              <div className="flex space-x-1 items-center ml-auto relative"> {/* ml-auto pushes buttons to the right */}
+                {/* Edit Button for Grid View */}
+                <button
+                  onClick={handleEdit}
+                  className="text-xs py-1 px-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+                >
+                  Edit
+                </button>
+
+                {/* Update Now Button for Grid View */}
+                <button
+                  onClick={handleUpdateNow}
+                  disabled={updating}
+                  className={`text-xs py-1 px-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors ${
+                    updating ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                >
+                  {updating ? 'Updating...' : 'Update Now'}
+                </button>
+
+                {/* Delete Button for Grid View */}
+                <button
+                  onClick={handleDeleteStream}
+                  className="text-xs py-1 px-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
+                >
+                  Delete Stream
+                </button>
+
+                {/* Export Button for Grid View */}
+                <button
+                  onClick={() => setShowExportOptions(!showExportOptions)}
+                  className="text-xs py-1 px-2 rounded bg-gray-600 text-white hover:bg-gray-700 transition-colors"
+                >
+                  Export
+                </button>
+
+                {/* Export Options Dropdown - positioned relative to this container */}
+                {showExportOptions && (
+                  <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
+                    <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
+                      <button
+                        onClick={() => { copyToClipboard(); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Copy to Clipboard
+                      </button>
+                      <button
+                        onClick={() => { exportAsFile('md'); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Export as .md
+                      </button>
+                      <button
+                        onClick={() => { exportAsFile('txt'); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Export as .txt
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              // List View Layout: Edit/Update on first line, Delete/Export on second, both right-aligned
+              <div className="flex flex-col items-end space-y-1 relative"> {/* items-end aligns flex items to the right */}
+                {/* First line: Edit, Update Now */}
+                <div className="flex space-x-1"> {/* Container for first line buttons */}
+                  <button
+                    onClick={handleEdit}
+                    className="text-xs py-1 px-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={handleUpdateNow}
+                    disabled={updating}
+                    className={`text-xs py-1 px-2 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors ${
+                      updating ? 'opacity-50 cursor-not-allowed' : ''
+                    }`}
+                  >
+                    {updating ? 'Updating...' : 'Update Now'}
+                  </button>
                 </div>
-                <MarkdownRenderer content={selectedSummary.content} />
+
+                {/* Second line: Delete, Export */}
+                <div className="flex space-x-1 justify-end w-full"> {/* Ensure buttons are right-aligned on this line */}
+                  <button
+                    onClick={handleDeleteStream}
+                    className="text-xs py-1 px-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
+                  >
+                    Delete Stream
+                  </button>
+                  <button
+                    onClick={() => setShowExportOptions(!showExportOptions)}
+                    className="text-xs py-1 px-2 rounded bg-gray-600 text-white hover:bg-gray-700 transition-colors"
+                  >
+                    Export
+                  </button>
+                </div>
+
+                {/* Export Options Dropdown - positioned relative to the main flex-col container */}
+                {showExportOptions && (
+                  <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
+                    <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
+                      <button
+                        onClick={() => { copyToClipboard(); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Copy to Clipboard
+                      </button>
+                      <button
+                        onClick={() => { exportAsFile('md'); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Export as .md
+                      </button>
+                      <button
+                        onClick={() => { exportAsFile('txt'); setShowExportOptions(false); }}
+                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                        role="menuitem"
+                      >
+                        Export as .txt
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
-              
-              {/* Deep Dive Chat Section - Right Column */}
-              <div className="flex-1 basis-1/2 overflow-hidden">
-                <DeepDiveChat 
-                  topicStreamId={stream.id} 
-                  summaryId={selectedSummary.id}
-                  topic={stream.query}
-                  onAppend={handleAppendSummary}
-                />
+            )}
+          </div>
+
+          {error && !showDeleteStreamConfirm && (
+            <div className="p-4 bg-red-100 border-l-4 border-red-500 text-red-700">
+              <p>{error}</p>
+              <button onClick={() => setError('')} className="text-sm underline mt-1">Dismiss</button>
+            </div>
+          )}
+
+          <div className="divide-y dark:divide-gray-700">
+            {loading ? (
+              <div className="p-4 text-center text-gray-500 dark:text-gray-400">Loading summaries...</div>
+            ) : summaries.length === 0 && !error ? (
+              <div className="p-4 text-center text-gray-500 dark:text-gray-400">
+                No summaries yet. Click "Update Now" to generate one.
+              </div>
+            ) : (
+              summaries.map((summary) => (
+                <div key={summary.id} className="p-4">
+                  <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Summary</h4>
+                   <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                     <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
+                        {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
+                      </span>
+                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">{summary.model_type}</span>
+                   </div>
+                   <div className={`prose prose-sm max-w-none dark:prose-invert`}>
+                     <MarkdownRenderer content={summary.content} />
+                   </div>
+                   
+                   {/* Summary Actions */}
+                   <div className="flex space-x-2 mt-4">
+                      <button
+                       onClick={() => handleDeepDive(summary)}
+                       className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full"
+                     >
+                       Deep Dive
+                     </button>
+                      <SummaryDeleteButton 
+                       streamId={stream.id} 
+                       summaryId={summary.id}
+                       onSummaryDeleted={handleSummarySuccessfullyDeleted}
+                       onError={handleSummaryDeletionError} 
+                     />
+                   </div>
+                  
+                   {/* Summary Sources */}
+                   {summary.sources && summary.sources.length > 0 && (
+                     <div className="mt-3">
+                       <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
+                       <div className="flex flex-wrap gap-1">
+                         {summary.sources.map((source, index) => (
+                           <a
+                             key={index}
+                             href={typeof source === 'string' ? source : (source.url || source.name || source)}
+                             target="_blank"
+                             rel="noopener noreferrer"
+                             className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
+                             title={typeof source === 'string' ? source : (source.url || source.name || source)}
+                           >
+                             {typeof source === 'string' 
+                               ? source 
+                               : (source.name || source.url || source)}
+                           </a>
+                         ))}
+                       </div>
+                     </div>
+                   )}
+                </div>
+              ))
+            )}
+          </div>
+
+          {showDeepDive && selectedSummary && (
+            <div className="fixed inset-0 z-50 bg-gray-500 bg-opacity-75 flex items-center justify-center p-4">
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-3/4 max-h-[90vh] overflow-hidden flex flex-col">
+                <div className="p-4 border-b dark:border-gray-700 flex justify-between items-center">
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-blue-300 truncate flex-1 min-w-0">
+                    Deep Dive: {stream.query}
+                  </h3>
+                  <button
+                    onClick={() => setShowDeepDive(false)}
+                    className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+                  >
+                    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                
+                {/* Main content area with two columns */}
+                <div className="flex flex-1 overflow-hidden flex-row">
+                  {/* Original Summary Section - Left Column */}
+                  <div className="flex-1 basis-1/2 p-4 border-r dark:border-gray-700 overflow-y-auto">
+                    <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Summary</h4>
+                    <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                      {selectedSummary.created_at ? formatInTimeZone(toZonedTime(parseISO(selectedSummary.created_at), userTimeZone), userTimeZone, 'MMM d, yyyy h:mm a') : ''} • Model: {selectedSummary.model_type}
+                    </div>
+                    <MarkdownRenderer content={selectedSummary.content} />
+                  </div>
+                  
+                  {/* Deep Dive Chat Section - Right Column */}
+                  <div className="flex-1 basis-1/2 overflow-hidden">
+                    <DeepDiveChat 
+                      topicStreamId={stream.id} 
+                      summaryId={selectedSummary.id}
+                      topic={stream.query}
+                      onAppend={handleAppendSummary}
+                    />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-      )}
+          )}
 
-      {showDeleteStreamConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full shadow-xl">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Delete Topic Stream?
-            </h3>
-            <p className="text-gray-600 dark:text-gray-300 mb-6">
-              Are you sure you want to delete the entire topic stream "{stream.query}"? This action cannot be undone, and all associated summaries will be permanently deleted.
-            </p>
-            <div className="flex justify-end space-x-3">
-              <button
-                onClick={cancelDeleteStream}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={confirmDeleteStream}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700"
-              >
-                Delete Stream
-              </button>
+          {showDeleteStreamConfirm && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+              <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full shadow-xl">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+                  Delete Topic Stream?
+                </h3>
+                <p className="text-gray-600 dark:text-gray-300 mb-6">
+                  Are you sure you want to delete the entire topic stream "{stream.query}"? This action cannot be undone, and all associated summaries will be permanently deleted.
+                </p>
+                <div className="flex justify-end space-x-3">
+                  <button
+                    onClick={cancelDeleteStream}
+                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={confirmDeleteStream}
+                    className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700"
+                  >
+                    Delete Stream
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          )}
 
-      {/* Display copy feedback */}
-      {copyFeedback && (
-        <div className="absolute bottom-4 right-4 px-3 py-2 bg-gray-800 text-white text-sm rounded shadow-lg z-50">
-          {copyFeedback}
-        </div>
+          {/* Display copy feedback */}
+          {copyFeedback && (
+            <div className="absolute bottom-4 right-4 px-3 py-2 bg-gray-800 text-white text-sm rounded shadow-lg z-50">
+              {copyFeedback}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/frontend/src/components/TopicStreamWidget.jsx
+++ b/src/frontend/src/components/TopicStreamWidget.jsx
@@ -285,7 +285,7 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
             {/* Buttons - right side, need conditional layout */}
             {isGridView ? (
               // Grid View Layout: All buttons on one line, right-aligned
-              <div className="flex space-x-1 items-center ml-auto relative"> {/* ml-auto pushes buttons to the right */}
+              <div className="flex space-x-1 items-center relative"> {/* Removed ml-auto for left alignment */}
                 {/* Edit Button for Grid View */}
                 <button
                   onClick={handleEdit}

--- a/src/frontend/src/components/TopicStreamWidget.jsx
+++ b/src/frontend/src/components/TopicStreamWidget.jsx
@@ -438,54 +438,57 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
               summaries.map((summary) => (
                 <div key={summary.id} className="p-4">
                   <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Summary</h4>
-                   <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                     <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
-                        {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
-                      </span>
-                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">{summary.model_type}</span>
-                   </div>
-                   <div className={`prose prose-sm max-w-none dark:prose-invert`}>
-                     <MarkdownRenderer content={summary.content} />
-                   </div>
-                   
-                   {/* Summary Actions */}
-                   <div className="flex space-x-2 mt-4">
-                      <button
-                       onClick={() => handleDeepDive(summary)}
-                       className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full"
-                     >
-                       Deep Dive
-                     </button>
-                      <SummaryDeleteButton 
-                       streamId={stream.id} 
-                       summaryId={summary.id}
-                       onSummaryDeleted={handleSummarySuccessfullyDeleted}
-                       onError={handleSummaryDeletionError} 
-                     />
-                   </div>
-                  
-                   {/* Summary Sources */}
-                   {summary.sources && summary.sources.length > 0 && (
-                     <div className="mt-3">
-                       <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
-                       <div className="flex flex-wrap gap-1">
-                         {summary.sources.map((source, index) => (
-                           <a
-                             key={index}
-                             href={typeof source === 'string' ? source : (source.url || source.name || source)}
-                             target="_blank"
-                             rel="noopener noreferrer"
-                             className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
-                             title={typeof source === 'string' ? source : (source.url || source.name || source)}
-                           >
-                             {typeof source === 'string' 
-                               ? source 
-                               : (source.name || source.url || source)}
-                           </a>
-                         ))}
-                       </div>
-                     </div>
-                   )}
+                  {/* Timestamp, Model, and Summary Actions */}
+                  <div className="flex flex-wrap gap-2 items-center mb-2">
+                    {/* Timestamp Badge */}
+                    <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
+                      {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
+                    </span>
+                    {/* Model Badge */}
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">{summary.model_type}</span>
+
+                    {/* Summary Actions - Deep Dive and Delete */}
+                    <div className="flex space-x-2 items-center ml-auto"> {/* Added ml-auto to push buttons to the right */}
+                       <button
+                        onClick={() => handleDeepDive(summary)}
+                        className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full"
+                      >
+                        Deep Dive
+                      </button>
+                       <SummaryDeleteButton
+                        streamId={stream.id}
+                        summaryId={summary.id}
+                        onSummaryDeleted={handleSummarySuccessfullyDeleted}
+                        onError={handleSummaryDeletionError}
+                      />
+                    </div>
+                  </div>
+                  <div className={`prose prose-sm max-w-none dark:prose-invert`}>
+                    <MarkdownRenderer content={summary.content} />
+                  </div>
+
+                  {/* Summary Sources */}
+                  {summary.sources && summary.sources.length > 0 && (
+                    <div className="mt-3">
+                      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
+                      <div className="flex flex-wrap gap-1">
+                        {summary.sources.map((source, index) => (
+                          <a
+                            key={index}
+                            href={typeof source === 'string' ? source : (source.url || source.name || source)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
+                            title={typeof source === 'string' ? source : (source.url || source.name || source)}
+                          >
+                            {typeof source === 'string' 
+                              ? source 
+                              : (source.name || source.url || source)}
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               ))
             )}

--- a/src/frontend/src/components/TopicStreamWidget.jsx
+++ b/src/frontend/src/components/TopicStreamWidget.jsx
@@ -284,8 +284,7 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
             
             {/* Buttons - right side, need conditional layout */}
             {isGridView ? (
-              // Grid View Layout: All buttons on one line, right-aligned
-              <div className="flex space-x-1 items-center relative"> {/* Removed ml-auto for left alignment */}
+              <div className="flex space-x-1 items-center relative"> {/* Left-aligned */}
                 {/* Edit Button for Grid View */}
                 <button
                   onClick={handleEdit}
@@ -323,7 +322,7 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
 
                 {/* Export Options Dropdown - positioned relative to this container */}
                 {showExportOptions && (
-                  <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
+                  <div className="absolute left-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-10"> {/* Position dropdown */}
                     <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
                       <button
                         onClick={() => { copyToClipboard(); setShowExportOptions(false); }}
@@ -351,7 +350,6 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
                 )}
               </div>
             ) : (
-              // List View Layout: Edit/Update on first line, Delete/Export on second, both right-aligned
               <div className="flex flex-col items-end space-y-1 relative"> {/* items-end aligns flex items to the right */}
                 {/* First line: Edit, Update Now */}
                 <div className="flex space-x-1"> {/* Container for first line buttons */}
@@ -447,13 +445,13 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
                     {/* Model Badge */}
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">{summary.model_type}</span>
 
-                    {/* Summary Actions - Deep Dive and Delete */}
-                    <div className="flex space-x-2 items-center ml-auto"> {/* Added ml-auto to push buttons to the right */}
+                    {/* Summary Actions - Deep Dive Chat and Delete */}
+                    <div className="flex space-x-2 items-center ml-auto"> {/* Added ml-auto to push to the right */}
                        <button
                         onClick={() => handleDeepDive(summary)}
                         className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full"
                       >
-                        Deep Dive
+                        Deep Dive Chat
                       </button>
                        <SummaryDeleteButton
                         streamId={stream.id}
@@ -479,7 +477,7 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
-                            title={typeof source === 'string' ? source : (source.url || source.name || source)}
+                            title={typeof source === 'string' ? source : (source.url || source)}
                           >
                             {typeof source === 'string' 
                               ? source 
@@ -540,7 +538,7 @@ const TopicStreamWidget = ({ stream, onDelete, onUpdate, isGridView }) => {
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
               <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full shadow-xl">
                 <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-                  Delete Topic Stream?
+                  Delete Topic Stream
                 </h3>
                 <p className="text-gray-600 dark:text-gray-300 mb-6">
                   Are you sure you want to delete the entire topic stream "{stream.query}"? This action cannot be undone, and all associated summaries will be permanently deleted.

--- a/src/frontend/src/pages/Dashboard.jsx
+++ b/src/frontend/src/pages/Dashboard.jsx
@@ -557,16 +557,9 @@ const Dashboard = () => {
               {viewMode === 'list' && (
                 <div className={`col-span-12 md:col-span-3 rounded-lg shadow-sm ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200 shadow-md'} sticky top-[69px] h-screen overflow-y-auto`}>
                   <div className={`p-4 border-b ${theme === 'dark' ? 'border-slate-700' : 'border-slate-200'}`}>
-                    <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300">Topic Streams</h2>
-                    <div className="flex space-x-2">
-                      {!loading && topicStreams.length > 0 && (
-                        <div className="text-xs text-slate-500 dark:text-slate-400 italic flex items-center">
-                          <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
-                          </svg>
-                          Drag to reorder
-                        </div>
-                      )}
+                    {/* Header Row */}
+                    <div className="flex justify-between items-center mb-2">
+                      <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300">Topic Streams</h2>
                       <button
                         onClick={() => setShowForm(true)}
                         className="bg-slate-100 hover:bg-slate-200 text-slate-700 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-200 px-3 py-1 rounded text-sm border border-slate-300 dark:border-slate-600"
@@ -575,6 +568,16 @@ const Dashboard = () => {
                         New Stream
                       </button>
                     </div>
+                    
+                    {/* Drag to reorder text below header row */}
+                    {!loading && topicStreams.length > 0 && (
+                      <div className="text-xs text-slate-500 dark:text-slate-400 italic flex items-center mt-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />
+                        </svg>
+                        Drag to reorder
+                      </div>
+                    )}
                   </div>
                   
                   {loading ? (

--- a/src/frontend/src/pages/Dashboard.jsx
+++ b/src/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,8 @@ import TopicStreamWidget from '../components/TopicStreamWidget'; // Correct rela
 import { format } from 'date-fns';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import DeepDiveChat from '../components/DeepDiveChat';
+import { formatDistanceToNowStrict, parseISO } from 'date-fns';
+import { formatInTimeZone, toZonedTime } from 'date-fns-tz';
 
 const Dashboard = () => {
   const { user, logout } = useContext(AuthContext);
@@ -70,6 +72,7 @@ const Dashboard = () => {
             ...summary,
             streamQuery: stream.query,
             streamId: stream.id,
+            detail_level: stream.detail_level,
             // Ensure we have a valid date for sorting
             created_at: summary.created_at || new Date().toISOString()
           })))
@@ -343,17 +346,30 @@ const Dashboard = () => {
   // Render a single summary item for the mobile feed
   const renderSummaryItem = (summary) => (
     <div key={summary.id} className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 mb-4">
-      {/* Summary Header */}
-      <div className="p-4 border-b border-slate-200 dark:border-slate-700">
+      {/* Summary Header - Make this sticky */}
+      <div className="p-4 border-b border-slate-200 dark:border-slate-700 sticky top-0 bg-white dark:bg-[#2a2a2e] z-10">
         <div className="flex justify-between items-center mb-2">
-          <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300 line-clamp-1 max-w-[75%]" title={summary.streamQuery}>{summary.streamQuery}</h3>
-          <span className="text-xs text-slate-500 dark:text-slate-400">
-            {summary.created_at ? format(new Date(summary.created_at), 'MMM d, yyyy h:mm a') : ''}
+          <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300 line-clamp-1 max-w-[75%] Camino text-ellipsis overflow-hidden" title={summary.streamQuery}>{summary.streamQuery}</h3>
+          <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
+            {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
           </span>
         </div>
         
-        {/* Stream Actions */}
-        <div className="flex space-x-2">
+        {/* Stream Actions and additional info badges */}
+        <div className="flex space-x-2 items-center">
+           {/* Model Badge */}
+           {summary.model && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+              {summary.model}
+            </span>
+          )}
+           {/* Detail Level Badge - use stream's detail level */}
+           {summary.detail_level && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+              {summary.detail_level}
+            </span>
+          )}
+
           <button 
             onClick={() => {
               const stream = topicStreams.find(s => s.id === summary.streamId);
@@ -380,7 +396,7 @@ const Dashboard = () => {
       
       {/* Summary Content */}
       <div className="p-4">
-        <div className="prose prose-sm max-w-none dark:prose-invert">
+        <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}>
           <MarkdownRenderer content={summary.content || ''} />
         </div>
       </div>
@@ -411,9 +427,9 @@ const Dashboard = () => {
   );
 
   return (
-    <div className={`min-h-screen ${theme === 'dark' ? 'bg-[#1c1c1e]' : 'bg-[#f7f7f8]'}`}>
+    <div className={`min-h-screen ${theme === 'dark' ? 'bg-[#1c1c1e]' : 'bg-slate-100'}`}>
       {/* Header */}
-      <header className={`shadow-sm border-b dark:border-slate-700 sticky top-0 z-50 ${theme === 'dark' ? 'bg-[#2a2a2e]' : 'bg-[#f7f7f8]'}`}>
+      <header className={`shadow-sm border-b ${theme === 'dark' ? 'border-slate-700 bg-[#2a2a2e]' : 'border-slate-200 bg-white'}`}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
           <h1 
             className="text-3xl font-bold text-slate-700 dark:text-slate-300 cursor-pointer hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
@@ -467,7 +483,7 @@ const Dashboard = () => {
               {/* Mobile View Header - moved inside the container */}
               {!showForm && topicStreams.length > 0 && !loading && !loadingSummaries && allSummaries.length > 0 ? (
                 <div className="mobile-feed pb-16 max-w-3xl mx-auto">
-                  <div className="flex justify-between items-center sticky top-[69px] pt-2 pb-4 bg-[#f7f7f8] dark:bg-[#1c1c1e] z-40">
+                  <div className="flex justify-between items-center pt-2 pb-4 bg-[#f7f7f8] dark:bg-[#1c1c1e] z-40">
                     <h2 className="text-xl font-medium text-slate-700 dark:text-slate-300">Latest Updates</h2>
                     <button
                       onClick={() => setShowForm(true)}
@@ -539,8 +555,8 @@ const Dashboard = () => {
             <div className="grid grid-cols-12 gap-6">
               {/* Sidebar: Conditionally render in DOM based on viewMode to simplify layout management */}
               {viewMode === 'list' && (
-                <div className="col-span-12 md:col-span-3 bg-[#f0f0f1] dark:bg-[#2a2a2e] rounded-lg shadow-sm border border-slate-200 dark:border-slate-700">
-                  <div className="p-4 border-b border-slate-200 dark:border-slate-700 flex justify-between items-center">
+                <div className={`col-span-12 md:col-span-3 rounded-lg shadow-sm ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200 shadow-md'} sticky top-0 h-screen overflow-y-auto`}>
+                  <div className={`p-4 border-b ${theme === 'dark' ? 'border-slate-700' : 'border-slate-200'}`}>
                     <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300">Topic Streams</h2>
                     <div className="flex space-x-2">
                       {!loading && topicStreams.length > 0 && (
@@ -610,7 +626,7 @@ const Dashboard = () => {
               {/* Main content area */}
               <div className={`${viewMode === 'list' ? 'col-span-12 md:col-span-9' : 'col-span-12'}`}>
                 {showForm ? (
-                  <div className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm p-6 border border-slate-200 dark:border-slate-700" data-testid="stream-form-container">
+                  <div className={`rounded-lg shadow-sm p-6 ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200'}`}>
                     <div className="flex justify-between items-center mb-6">
                       <h2 className="text-xl font-medium text-slate-700 dark:text-slate-300">Create New Topic Stream</h2>
                       <button
@@ -645,20 +661,24 @@ const Dashboard = () => {
                           <h3 className="text-md font-medium text-gray-700 dark:text-gray-300">More Streams</h3>
                         </div>
                         {topicStreams.slice(5).map(stream => (
-                          <TopicStreamWidget
-                            key={stream.id}
-                            stream={stream}
-                            onDelete={() => handleDeleteStream(stream.id)}
-                            onUpdate={handleUpdateStream}
-                            isGridView={true} 
-                          />
+                          <div key={stream.id}>
+                            <TopicStreamWidget
+                              key={stream.id}
+                              stream={stream}
+                              onDelete={() => handleDeleteStream(stream.id)}
+                              onUpdate={handleUpdateStream}
+                              isGridView={true} 
+                            />
+                          </div>
                         ))}
                       </>
                     )}
                     
                     {topicStreams.length === 0 && !loading && (
-                      <div className="col-span-full bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm p-6 text-center border border-slate-200 dark:border-slate-700">
-                        <p className="text-slate-500 dark:text-slate-400">No topic streams available to display in grid view.</p>
+                      <div className={`col-span-full rounded-lg shadow-sm p-6 text-center ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200'}`}>
+                        <p className="text-slate-500 dark:text-slate-400">
+                          No topic streams available to display in grid view.
+                        </p>
                       </div>
                     )}
                   </div>
@@ -670,7 +690,7 @@ const Dashboard = () => {
                     isGridView={false} 
                   />
                 ) : viewMode === 'list' ? (
-                  <div className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm p-6 text-center border border-slate-200 dark:border-slate-700" data-testid="no-selection-message">
+                  <div className={`rounded-lg shadow-sm p-6 text-center ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200'}`}>
                     <p className="text-slate-500 dark:text-slate-400">
                       Select a topic stream or create a new one to get started
                     </p>
@@ -718,40 +738,14 @@ const Dashboard = () => {
               <div className="w-1/2 p-4 border-r dark:border-gray-700 overflow-y-auto">
                 <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Original Summary</h4>
                 {/* Render summary with potential truncation and Read More - Keep as is for now */}
-                <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}> {/* Removed line-clamp, summary should be fully visible */}
+                <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}>
                     <MarkdownRenderer content={selectedSummary.content} />
                 </div>
-                 {/* Removed Read More button - summary is fully visible */}
-                 
-                {/* Summary Sources - Moved below summary content - Keep as is for now */}
-                {selectedSummary.sources && selectedSummary.sources.length > 0 && (
-                    <div className="mt-4">
-                        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
-                        <div className="flex flex-wrap gap-1">
-                            {selectedSummary.sources.map((source, index) => (
-                                <a
-                                    key={index}
-                                    href={source}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-xs text-indigo-600 hover:text-indigo-900 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900 px-2 py-1 rounded-full truncate max-w-[200px]"
-                                >
-                                    {source}
-                                </a>
-                            ))}
-                        </div>
-                    </div>
-                )}
               </div>
 
-              {/* Deep Dive Chat Section - Right Column */}
-              <div className="flex-1 overflow-hidden">
-                <DeepDiveChat 
-                  topicStreamId={selectedStream.id}
-                  summaryId={selectedSummary.id}
-                  topic={selectedStream.query}
-                  onAppend={handleAppendSummary}
-                />
+              {/* Additional Information Section - Right Column */}
+              <div className="w-1/2 p-4 border-l dark:border-gray-700 overflow-y-auto">
+                {/* Additional information content can be added here */}
               </div>
             </div>
           </div>
@@ -761,4 +755,4 @@ const Dashboard = () => {
   );
 };
 
-export default Dashboard; 
+export default Dashboard;

--- a/src/frontend/src/pages/Dashboard.jsx
+++ b/src/frontend/src/pages/Dashboard.jsx
@@ -347,7 +347,7 @@ const Dashboard = () => {
   const renderSummaryItem = (summary) => (
     <div key={summary.id} className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 mb-4">
       {/* Summary Header - Make this sticky */}
-      <div className="p-4 border-b border-slate-200 dark:border-slate-700 sticky top-0 bg-white dark:bg-[#2a2a2e] z-10">
+      <div className="p-4 border-b border-slate-200 dark:border-slate-700 sticky top-[69px] bg-white dark:bg-[#2a2a2e] z-10">
         <div className="flex justify-between items-center mb-2">
           <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300 line-clamp-1 max-w-[75%] Camino text-ellipsis overflow-hidden" title={summary.streamQuery}>{summary.streamQuery}</h3>
           <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
@@ -429,7 +429,7 @@ const Dashboard = () => {
   return (
     <div className={`min-h-screen ${theme === 'dark' ? 'bg-[#1c1c1e]' : 'bg-slate-100'}`}>
       {/* Header */}
-      <header className={`shadow-sm border-b ${theme === 'dark' ? 'border-slate-700 bg-[#2a2a2e]' : 'border-slate-200 bg-white'}`}>
+      <header className={`shadow-sm border-b ${theme === 'dark' ? 'border-slate-700 bg-[#2a2a2e]' : 'border-slate-200 bg-white'} sticky top-0 z-20 w-full`}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
           <h1 
             className="text-3xl font-bold text-slate-700 dark:text-slate-300 cursor-pointer hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
@@ -555,7 +555,7 @@ const Dashboard = () => {
             <div className="grid grid-cols-12 gap-6">
               {/* Sidebar: Conditionally render in DOM based on viewMode to simplify layout management */}
               {viewMode === 'list' && (
-                <div className={`col-span-12 md:col-span-3 rounded-lg shadow-sm ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200 shadow-md'} sticky top-0 h-screen overflow-y-auto`}>
+                <div className={`col-span-12 md:col-span-3 rounded-lg shadow-sm ${theme === 'dark' ? 'bg-[#2a2a2e] border-slate-700' : 'bg-white border-slate-200 shadow-md'} sticky top-[69px] h-screen overflow-y-auto`}>
                   <div className={`p-4 border-b ${theme === 'dark' ? 'border-slate-700' : 'border-slate-200'}`}>
                     <h2 className="text-lg font-medium text-slate-700 dark:text-slate-300">Topic Streams</h2>
                     <div className="flex space-x-2">

--- a/src/frontend/src/pages/Dashboard.jsx
+++ b/src/frontend/src/pages/Dashboard.jsx
@@ -344,87 +344,106 @@ const Dashboard = () => {
   const viewModeUI = getViewModeUI();
 
   // Render a single summary item for the mobile feed
-  const renderSummaryItem = (summary) => (
-    <div key={summary.id} className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 mb-4">
-      {/* Summary Header - Make this sticky */}
-      <div className="p-4 border-b border-slate-200 dark:border-slate-700 sticky top-[69px] bg-white dark:bg-[#2a2a2e] z-10">
-        <div className="flex justify-between items-center mb-2">
-          <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300 line-clamp-1 max-w-[75%] Camino text-ellipsis overflow-hidden" title={summary.streamQuery}>{summary.streamQuery}</h3>
-          <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
-            {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
-          </span>
-        </div>
-        
-        {/* Stream Actions and additional info badges */}
-        <div className="flex space-x-2 items-center">
-           {/* Model Badge */}
-           {summary.model && (
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-              {summary.model}
-            </span>
-          )}
-           {/* Detail Level Badge - use stream's detail level */}
-           {summary.detail_level && (
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-              {summary.detail_level}
-            </span>
-          )}
-
-          <button 
-            onClick={() => {
-              const stream = topicStreams.find(s => s.id === summary.streamId);
-              if (stream) handleUpdateNow(stream.id);
-            }}
-            className="text-xs py-1 px-2 bg-blue-50 text-blue-600 dark:bg-blue-900 dark:text-blue-200 rounded-full"
-          >
-            Update
-          </button>
-          <button
-            onClick={() => {
-              const streamIndex = topicStreams.findIndex(s => s.id === summary.streamId);
-              if (streamIndex >= 0) {
-                setViewMode('list');
-                setSelectedStream(topicStreams[streamIndex]);
-              }
-            }}
-            className="text-xs py-1 px-2 bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-full"
-          >
-            View All
-          </button>
-        </div>
-      </div>
-      
-      {/* Summary Content */}
-      <div className="p-4">
-        <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}>
-          <MarkdownRenderer content={summary.content || ''} />
-        </div>
-      </div>
-      
-      {/* Summary Sources */}
-      {summary.sources && summary.sources.length > 0 && (
-        <div className="px-4 pb-4">
-          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
-          <div className="flex flex-wrap gap-1">
-            {summary.sources.map((source, index) => (
-              <a
-                key={index}
-                href={typeof source === 'string' ? source : source.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
-                title={typeof source === 'string' ? source : (source.url || source)}
+  const renderSummaryItem = (summary) => {
+    return (
+      <div key={summary.id} className="bg-white dark:bg-[#2a2a2e] rounded-lg shadow-sm border border-slate-200 dark:border-slate-700 mb-4 p-3">
+        {/* Summary Header */}
+        <div className="border-b border-slate-200 dark:border-slate-700 sticky top-[69px] bg-white dark:bg-[#2a2a2e] z-10 pb-3">
+          <div className="flex justify-between items-start mb-2">
+            <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300 line-clamp-2 max-w-[80%] Camino text-ellipsis overflow-hidden" title={summary.streamQuery}>{summary.streamQuery}</h3>
+            {/* Combine Timestamp and Deep Dive button in a right-aligned container */}
+            <div className="flex flex-col items-end flex-shrink-0">
+              <span className="text-xs px-2.5 py-0.5 rounded-full bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 font-medium">
+                {summary.created_at ? formatInTimeZone(toZonedTime(parseISO(summary.created_at + 'Z'), Intl.DateTimeFormat().resolvedOptions().timeZone), Intl.DateTimeFormat().resolvedOptions().timeZone, 'MMM d, yyyy h:mm a') : ''}
+              </span>
+              {/* Deep Dive Chat button */}
+              <button
+                onClick={() => {
+                  setShowDeepDive(true);
+                  setSelectedSummary(summary);
+                }}
+                className="text-xs bg-indigo-50 dark:bg-indigo-900 text-indigo-600 dark:text-indigo-300 px-2 py-1 rounded-full mt-1"
               >
-                {typeof source === 'string' 
-                  ? source 
-                  : (source.name || source.url || source)}
-              </a>
-            ))}
+                Deep Dive Chat
+              </button>
+            </div>
+          </div>
+          
+          {/* Stream Actions and additional info badges - Now on the same line */}
+          <div className="flex flex-wrap gap-2 items-center">
+             {/* Model Badge */}
+             {summary.model && (
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+                {summary.model}
+              </span>
+            )}
+             {/* Detail Level Badge - use stream's detail level */}
+             {summary.detail_level && (
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                {summary.detail_level}
+              </span>
+            )}
+
+            {/* Update and View All buttons - Moved here */}
+            {/* Update button */}
+            <button
+              onClick={() => {
+                const stream = topicStreams.find(s => s.id === summary.streamId);
+                if (stream) handleUpdateNow(stream.id);
+              }}
+              className="text-xs py-1 px-2 bg-blue-50 text-blue-600 dark:bg-blue-900 dark:text-blue-200 rounded-full"
+            >
+              Update
+            </button>
+
+            {/* View All button */}
+            <button
+              onClick={() => {
+                const streamIndex = topicStreams.findIndex(s => s.id === summary.streamId);
+                if (streamIndex >= 0) {
+                  setViewMode('list');
+                  setSelectedStream(topicStreams[streamIndex]);
+                }
+              }}
+              className="text-xs py-1 px-2 bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded-full"
+            >
+              View All
+            </button>
           </div>
         </div>
-      )}
-    </div>
-  );
+        
+        {/* Summary Content */}
+        <div className="p-4 pt-2">
+          <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}>
+            <MarkdownRenderer content={summary.content || ''} />
+          </div>
+        </div>
+        
+        {/* Summary Sources */}
+        {summary.sources && summary.sources.length > 0 && (
+          <div className="px-4 pb-4">
+            <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Sources:</div>
+            <div className="flex flex-wrap gap-1">
+              {summary.sources.map((source, index) => (
+                <a
+                  key={index}
+                  href={typeof source === 'string' ? source : source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 px-2 py-1 rounded-full truncate max-w-[200px]"
+                  title={typeof source === 'string' ? source : (source.url || source)}
+                >
+                  {typeof source === 'string' 
+                    ? source 
+                    : (source.name || source.url || source)}
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className={`min-h-screen ${theme === 'dark' ? 'bg-[#1c1c1e]' : 'bg-slate-100'}`}>
@@ -715,8 +734,8 @@ const Dashboard = () => {
       )}
 
       {showDeepDive && selectedSummary && (
-        <div className="fixed inset-0 z-50 bg-gray-500 bg-opacity-75 flex items-center justify-center p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="fixed inset-0 z-50 bg-gray-500 bg-opacity-75 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col" style={{ maxWidth: '1000px !important' }}>
             <div className="p-4 border-b dark:border-gray-700 flex justify-between items-center">
               {/* Truncated Stream Title */}
               <div className="flex-1 overflow-hidden min-w-0 mr-4">
@@ -735,10 +754,10 @@ const Dashboard = () => {
             </div>
 
             {/* Main content area with two columns */}
-            <div className="flex flex-1 overflow-hidden flex-row">
+            <div className="flex overflow-hidden flex-row w-full">
 
               {/* Original Summary Section - Left Column */}
-              <div className="w-1/2 p-4 border-r dark:border-gray-700 overflow-y-auto">
+              <div className="p-4 border-r dark:border-gray-700 overflow-y-auto flex-grow basis-0">
                 <h4 className="text-md font-medium text-gray-700 dark:text-gray-300 mb-2">Original Summary</h4>
                 {/* Render summary with potential truncation and Read More - Keep as is for now */}
                 <div className={`prose prose-sm max-w-none dark:prose-invert ${!isSummaryExpanded ? '' : ''}`}>
@@ -746,9 +765,14 @@ const Dashboard = () => {
                 </div>
               </div>
 
-              {/* Additional Information Section - Right Column */}
-              <div className="w-1/2 p-4 border-l dark:border-gray-700 overflow-y-auto">
-                {/* Additional information content can be added here */}
+              {/* Deep Dive Chat Section - Right Column */}
+              <div className="p-4 border-l dark:border-gray-700 overflow-y-auto flex-grow basis-0">
+                 <DeepDiveChat 
+                    topicStreamId={selectedStream.id} 
+                    summaryId={selectedSummary.id}
+                    topic={selectedStream.query}
+                    onAppend={handleAppendSummary}
+                  />
               </div>
             </div>
           </div>


### PR DESCRIPTION
- TImestamp fixed (for EST), sticky header in Feed view. Time stamp UI changed to button style, light mode change : background off-white with shadow. Export stream added : copy to clipboard, export to .txt or .md.
- Re-added and fixed the "Edit" functionality for Topic Streams: Ensured the "Edit" button is present in both List and Grid views. Modified TopicStreamWidget.jsx to display the TopicStreamForm inline when "Edit" is clicked, pre-filling it with the stream's data for editing. Added padding around the edit form for better visual spacing. Added the "Edit Topic Stream" heading above the form. Improved the TopicStreamForm component: Added a "Cancel" button that appears during editing and closes the form. Styled the "Cancel" button to be full width with a white background, positioned below the "Update Topic Stream" button. Changed the "Topic Query" input field to a vertically resizable textarea.
- Fixed: Topic Streams sidebar (New Stream button now in line with Topic Streams text),
- DeepDive/Delete buttons moved back to the top of the summary to the right of the timestamp/model buttons.
- Grid view: buttons left alligned.
- Attempting to add deep dive chat to feed view. added but chat window is too small from mobile view forcing issue. something in CSS is causing this likely. 2.5 flash unable to find/resolve the issue